### PR TITLE
PR Candidate for non oplog support

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1253,9 +1253,9 @@ Ap.insertUserDoc = function (options, user) {
     // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
     if (e.name !== 'MongoError') throw e;
     if (e.code !== 11000) throw e;
-    if (e.err.indexOf('emails.address') !== -1)
+    if (e.errmsg.indexOf('emails.address') !== -1)
       throw new Meteor.Error(403, "Email already exists.");
-    if (e.err.indexOf('username') !== -1)
+    if (e.errmsg.indexOf('username') !== -1)
       throw new Meteor.Error(403, "Username already exists.");
     // XXX better error reporting for services.facebook.id duplicate, etc
     throw e;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -566,7 +566,7 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
               // inserting a new doc and we know its id, then
               // return that id as well.
 
-              if (options.upsert && knownId) {
+              if (options.upsert && meteorResult.insertedId && knownId) {
                 meteorResult.insertedId = knownId;
               }
               callback(err, meteorResult);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -566,15 +566,8 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
               // inserting a new doc and we know its id, then
               // return that id as well.
 
-              //transformResult was able to provide an id for some cases
-              //where the API did not wanted an ID. This needs furter looking
-              //but it fully complies with the test suite.
-              if (options.upsert) {
-                if (meteorResult.insertedId && knownId) {
-                  meteorResult.insertedId = knownId;
-                } else {
-                  delete meteorResult.insertedId;
-                }
+              if (options.upsert && knownId) {
+                meteorResult.insertedId = knownId;
               }
               callback(err, meteorResult);
             } else {
@@ -616,18 +609,18 @@ var transformResult = function (driverResult) {
     if (mongoResult.upserted) {
       //On updates with upsert:true, the inserted values come as a list of upserted values
       //Even with multi, when the upsert does insert, it only inserts one element
-      meteorResult.numberAffected += mongoResult.upserted.length;
+      meteorResult.numberAffected = mongoResult.upserted.length;
 
-      if(mongoResult.upserted.length == 1){
+      if (mongoResult.upserted.length == 1) {
         meteorResult.insertedId = mongoResult.upserted[0]._id;
       }
     } else {
       //The remove call, resturns only {ok: 1, n: [number of removed documents]}
       //update apis return the nModified with the number of changed documents
       if(mongoResult.nModified != null){
-        meteorResult.numberAffected += mongoResult.nModified;
-      } else if(mongoResult.n) {
-        meteorResult.numberAffected += mongoResult.n;
+        meteorResult.numberAffected = mongoResult.nModified;
+      } else if (mongoResult.n) {
+        meteorResult.numberAffected = mongoResult.n;
       }
     }
   }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -18,6 +18,7 @@ MongoTest = {};
 MongoInternals.NpmModules = {
   mongodb: {
     version: NpmModuleMongodbVersion,
+    module: MongoDB,
   }
 };
 

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -617,7 +617,7 @@ var transformResult = function (driverResult) {
     } else {
       //The remove call, resturns only {ok: 1, n: [number of removed documents]}
       //update apis return the nModified with the number of changed documents
-      if(mongoResult.nModified != null){
+      if (mongoResult.nModified != null) {
         meteorResult.numberAffected = mongoResult.nModified;
       } else if (mongoResult.n) {
         meteorResult.numberAffected = mongoResult.n;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -18,7 +18,6 @@ MongoTest = {};
 MongoInternals.NpmModules = {
   mongodb: {
     version: NpmModuleMongodbVersion,
-    module: MongoDB
   }
 };
 
@@ -559,9 +558,8 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
       collection.update(
         mongoSelector, mongoMod, mongoOpts,
         bindEnvironmentForWrite(function (err, result) {
-          var meteorResult;
           if (! err) {
-            meteorResult = transformResult(result);
+            var meteorResult = transformResult(result);
             if (meteorResult && options._returnObject) {
               // If this was an upsert() call, and we ended up
               // inserting a new doc and we know its id, then
@@ -570,8 +568,8 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
               //transformResult was able to provide an id for some cases
               //where the API did not wanted an ID. This needs furter looking
               //but it fully complies with the test suite.
-              if(options.upsert){
-                if(meteorResult.insertedId && knownId){
+              if (options.upsert) {
+                if (meteorResult.insertedId && knownId) {
                   meteorResult.insertedId = knownId;
                 } else {
                   delete meteorResult.insertedId;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -410,8 +410,11 @@ MongoConnection.prototype._remove = function (collection_name, selector,
 
   try {
     var collection = self.rawCollection(collection_name);
+    var wrappedCallback = function(err, driverResult) {
+      callback(err, transformResult(driverResult).numberAffected);
+    };
     collection.remove(replaceTypes(selector, replaceMeteorAtomWithMongo),
-                      {safe: true}, callback);
+                       {safe: true}, wrappedCallback);
   } catch (e) {
     write.committed();
     throw e;
@@ -555,19 +558,32 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
     } else {
       collection.update(
         mongoSelector, mongoMod, mongoOpts,
-        bindEnvironmentForWrite(function (err, result, extra) {
+        bindEnvironmentForWrite(function (err, result) {
+          var meteorResult;
           if (! err) {
-            if (result && options._returnObject) {
-              result = { numberAffected: result };
+            meteorResult = transformResult(result);
+            if (meteorResult && options._returnObject) {
               // If this was an upsert() call, and we ended up
               // inserting a new doc and we know its id, then
               // return that id as well.
-              if (options.upsert && knownId &&
-                  ! extra.updatedExisting)
-                result.insertedId = knownId;
+
+              //transformResult was able to provide an id for some cases
+              //where the API did not wanted an ID. This needs furter looking
+              //but it fully complies with the test suite.
+              if(options.upsert){
+                if(meteorResult.insertedId && knownId){
+                  meteorResult.insertedId = knownId;
+                } else {
+                  delete meteorResult.insertedId;
+                }
+              }
+              callback(err, meteorResult);
+            } else {
+              callback(err, meteorResult.numberAffected);
             }
+          } else {
+            callback(err);
           }
-          callback(err, result);
         }));
     }
   } catch (e) {
@@ -593,6 +609,34 @@ var isModificationMod = function (mod) {
   return isModify;
 };
 
+var transformResult = function (driverResult) {
+  var meteorResult = { numberAffected: 0 };
+  if (driverResult) {
+    mongoResult = driverResult.result;
+
+    //The remove call, resturns only {ok: 1, n: [number of removed documents]}
+    //update apis return the nModified with the number of changed documents
+    if(mongoResult.nModified != null){
+      meteorResult.numberAffected += mongoResult.nModified;
+    } else if(mongoResult.n) {
+      meteorResult.numberAffected += mongoResult.n;
+    }
+
+    //On updates with upsert:true, the inserted values come as a list of upserted values
+    //Even with multi, when the upsert does insert, it only inserts one element
+    if(mongoResult.upserted){
+      meteorResult.numberAffected += mongoResult.upserted.length;
+
+      if(mongoResult.upserted.length == 1){
+        meteorResult.insertedId = mongoResult.upserted[0]._id;
+      }
+    }
+  }
+
+  return meteorResult;
+};
+
+
 var NUM_OPTIMISTIC_TRIES = 3;
 
 // exposed for testing
@@ -601,13 +645,13 @@ MongoConnection._isCannotChangeIdError = function (err) {
   // checks should work, but just to be safe...
   if (err.code === 13596)
     return true;
-  if (err.err.indexOf("cannot change _id of a document") === 0)
+  if (err.errmsg.indexOf("cannot change _id of a document") === 0)
     return true;
 
   // Now look for what it looks like in Mongo 2.6.  We don't use the error code
   // here, because the error code we observed it producing (16837) appears to be
   // a far more generic error code based on examining the source.
-  if (err.err.indexOf("The _id field cannot be changed") === 0)
+  if (err.errmsg.indexOf("The _id field cannot be changed") === 0)
     return true;
 
   return false;
@@ -695,10 +739,11 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
                         bindEnvironmentForWrite(function (err, result) {
                           if (err)
                             callback(err);
-                          else if (result)
+                          else if (result && result.result.nModified != 0){
                             callback(null, {
-                              numberAffected: result
+                              numberAffected: result.result.nModified
                             });
+                          }
                           else
                             doConditionalInsert();
                         }));
@@ -722,8 +767,8 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
                           }
                         } else {
                           callback(null, {
-                            numberAffected: result,
-                            insertedId: insertedId
+                            numberAffected: result.result.upserted.length,
+                            insertedId: insertedId,
                           });
                         }
                       }));

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -610,23 +610,23 @@ var isModificationMod = function (mod) {
 var transformResult = function (driverResult) {
   var meteorResult = { numberAffected: 0 };
   if (driverResult) {
-    mongoResult = driverResult.result;
+    var mongoResult = driverResult.result;
 
-    //The remove call, resturns only {ok: 1, n: [number of removed documents]}
-    //update apis return the nModified with the number of changed documents
-    if(mongoResult.nModified != null){
-      meteorResult.numberAffected += mongoResult.nModified;
-    } else if(mongoResult.n) {
-      meteorResult.numberAffected += mongoResult.n;
-    }
-
-    //On updates with upsert:true, the inserted values come as a list of upserted values
-    //Even with multi, when the upsert does insert, it only inserts one element
-    if(mongoResult.upserted){
+    if (mongoResult.upserted) {
+      //On updates with upsert:true, the inserted values come as a list of upserted values
+      //Even with multi, when the upsert does insert, it only inserts one element
       meteorResult.numberAffected += mongoResult.upserted.length;
 
       if(mongoResult.upserted.length == 1){
         meteorResult.insertedId = mongoResult.upserted[0]._id;
+      }
+    } else {
+      //The remove call, resturns only {ok: 1, n: [number of removed documents]}
+      //update apis return the nModified with the number of changed documents
+      if(mongoResult.nModified != null){
+        meteorResult.numberAffected += mongoResult.nModified;
+      } else if(mongoResult.n) {
+        meteorResult.numberAffected += mongoResult.n;
       }
     }
   }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -180,8 +180,10 @@ MongoConnection = function (url, options) {
         }
 
         // First, figure out what the current primary is, if any.
-        if (db.serverConfig._state.master)
-          self._primary = db.serverConfig._state.master.name;
+        if (db.serverConfig.isMasterDoc) {
+          self._primary = db.serverConfig.isMasterDoc.primary;
+        }
+
         db.serverConfig.on(
           'joined', Meteor.bindEnvironment(function (kind, doc) {
             if (kind === 'primary') {

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3235,7 +3235,7 @@ Meteor.isServer && Tinytest.add(
 
 Meteor.isServer && Tinytest.add("mongo-livedata - npm modules", function (test) {
   // Make sure the version number looks like a version number.
-  test.matches(MongoInternals.NpmModules.mongodb.version, /^1\.(\d+)\.(\d+)/);
+  test.matches(MongoInternals.NpmModules.mongodb.version, /^2\.(\d+)\.(\d+)/);
   test.equal(typeof(MongoInternals.NpmModules.mongodb.module), 'function');
   test.equal(typeof(MongoInternals.NpmModules.mongodb.module.connect),
              'function');

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -84,6 +84,7 @@ Package.onTest(function (api) {
   // XXX test order dependency: the allow_tests "partial allow" test
   // fails if it is run before mongo_livedata_tests.
   api.addFiles('mongo_livedata_tests.js', ['client', 'server']);
+  api.addFiles('upsert_compatibility_test.js', ['server']);
   api.addFiles('allow_tests.js', ['client', 'server']);
   api.addFiles('collection_tests.js', ['client', 'server']);
   api.addFiles('observe_changes_tests.js', ['client', 'server']);

--- a/packages/mongo/upsert_compatibility_test.js
+++ b/packages/mongo/upsert_compatibility_test.js
@@ -1,0 +1,153 @@
+if(Meteor.isServer){
+  Tinytest.add('mongo livedata - native upsert - id type MONGO with MODIFIERS update', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'MONGO'});
+
+    coll.insert({foo: 1});
+    var result = coll.upsert({foo: 1}, {$set: {foo:2}});
+    var updated = coll.findOne({foo: 2});
+
+    test.equal(result.insertedId, undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(updated._id instanceof Mongo.ObjectID);
+
+    delete updated['_id'];
+    test.equal(EJSON.equals(updated, {foo: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type MONGO with MODIFIERS insert', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'MONGO'});
+
+    var result = coll.upsert({foo: 1}, {$set: {bar:2}});
+    var inserted = coll.findOne({foo: 1});
+
+    test.isTrue(result.insertedId !== undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(inserted._id instanceof Mongo.ObjectID);
+    test.equal(inserted._id, result.insertedId)
+
+    delete inserted['_id'];
+    test.equal(EJSON.equals(inserted, {foo: 1, bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type MONGO PLAIN OBJECT update', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'MONGO'});
+
+    coll.insert({foo: 1, baz: 42});
+    var result = coll.upsert({foo: 1}, {bar:2});
+    var updated = coll.findOne({bar: 2});
+
+    test.isTrue(result.insertedId === undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(updated._id instanceof Mongo.ObjectID);
+
+    delete updated['_id'];
+    test.equal(EJSON.equals(updated, {bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type MONGO PLAIN OBJECT insert', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'MONGO'});
+
+    var result = coll.upsert({foo: 1}, {bar:2});
+    var inserted = coll.findOne({bar: 2});
+
+    test.isTrue(result.insertedId !== undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(inserted._id instanceof Mongo.ObjectID);
+    test.isTrue(result.insertedId instanceof Mongo.ObjectID);
+    test.equal(inserted._id, result.insertedId);
+
+    delete inserted['_id'];
+    test.equal(EJSON.equals(inserted, {bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type STRING with MODIFIERS update', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'STRING'});
+
+    coll.insert({foo: 1});
+    var result = coll.upsert({foo: 1}, {$set: {foo:2}});
+    var updated = coll.findOne({foo: 2});
+
+    test.equal(result.insertedId, undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(typeof updated._id === 'string');
+
+    delete updated['_id'];
+    test.equal(EJSON.equals(updated, {foo: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type STRING with MODIFIERS insert', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'STRING'});
+
+    var result = coll.upsert({foo: 1}, {$set: {bar:2}});
+    var inserted = coll.findOne({foo: 1});
+
+    test.isTrue(result.insertedId !== undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(typeof inserted._id === 'string');
+    test.equal(inserted._id, result.insertedId);
+
+    delete inserted['_id'];
+    test.equal(EJSON.equals(inserted, {foo: 1, bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type STRING PLAIN OBJECT update', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'STRING'});
+
+    coll.insert({foo: 1, baz: 42});
+    var result = coll.upsert({foo: 1}, {bar:2});
+    var updated = coll.findOne({bar: 2});
+
+    test.isTrue(result.insertedId === undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(typeof updated._id === 'string');
+
+    delete updated['_id'];
+    test.equal(EJSON.equals(updated, {bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - id type STRING PLAIN OBJECT insert', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'STRING'});
+
+    var result = coll.upsert({foo: 1}, {bar:2});
+    var inserted = coll.findOne({bar: 2});
+
+    test.isTrue(result.insertedId !== undefined);
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(typeof inserted._id === 'string');
+    test.equal(inserted._id, result.insertedId);
+
+    delete inserted['_id'];
+    test.equal(EJSON.equals(inserted, {bar: 2}), true);
+  });
+
+  Tinytest.add('mongo livedata - native upsert - MONGO passing id insert', function (test) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('native_upsert_'+collName, {idGeneration: 'MONGO'});
+
+    var result = coll.upsert({foo: 1}, {_id: 'meu id'});
+    var inserted = coll.findOne({_id: 'meu id'});
+
+    test.equal(result.insertedId, 'meu id');
+    test.equal(result.numberAffected, 1);
+
+    test.isTrue(typeof inserted._id === 'string');
+
+    test.equal(EJSON.equals(inserted, {_id: 'meu id'}), true);
+  });
+}

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -1,26 +1,48 @@
 {
   "dependencies": {
     "mongodb": {
-      "version": "1.4.39",
-      "resolved": "https://github.com/meteor/node-mongodb-native/tarball/9c7441e87fbec059dc0b70bbb70734404b994d71",
-      "from": "https://github.com/meteor/node-mongodb-native/tarball/9c7441e87fbec059dc0b70bbb70734404b994d71",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "dependencies": {
-        "bson": {
-          "version": "0.2.18",
-          "resolved": "https://github.com/meteor/js-bson/tarball/0103b53",
-          "from": "https://github.com/meteor/js-bson/tarball/0103b53",
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+        },
+        "mongodb-core": {
+          "version": "1.3.18",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "dependencies": {
-            "nan": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz"
+            "bson": {
+              "version": "0.4.23",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+              "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+            },
+            "require_optional": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+              "dependencies": {
+                "resolve-from": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                },
+                "semver": {
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                }
+              }
             }
           }
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "version": "1.0.31",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -33,24 +55,14 @@
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         }

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -13,7 +13,7 @@ Npm.depends({
   // publish-for-arch dance every time we make a Meteor release.
   // XXX move the npm dependency into a non-core versioned package and allow
   //     it to use C++ bson
-  mongodb: "https://github.com/meteor/node-mongodb-native/tarball/9c7441e87fbec059dc0b70bbb70734404b994d71"
+  mongodb: "2.1.18"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
First steps towards updating to Mongo 3.2 with npm-mongodb-native 2.1.18. (https://github.com/meteor/meteor/issues/6957).

This PR changes the driver and add fixes to support connection `without oplog`.
- Changes the driver
- Adds `transformResult` to mongo_driver.js and uses it to convert the results from the new driver to what meteor expects to return on collection API.
- Fix all tests
- Adds some new tests that ensure some upsert behaviour (maybe not needed, but very useful during the transition

Future PRs will
- Add back the support to oplog.
- Update the mongo on dev bundle to 3.2 and test many platforms.
- (maybe) actually use native.upsert instead of update/insert (support is almost ready)
